### PR TITLE
Port cargo plugin to tomli

### DIFF
--- a/requirements/mypy-requirements.txt
+++ b/requirements/mypy-requirements.txt
@@ -1,7 +1,4 @@
 # Additional requirements for running mypy
 
-# For cargo plugin
-types-toml
-
 # For docker plugin
 types-requests

--- a/requirements/plugin-requirements.txt
+++ b/requirements/plugin-requirements.txt
@@ -2,7 +2,7 @@
 # aren't required for buildstream-plugins to be installed.
 
 # Cargo source
-toml
+tomli
 
 # Docker source
 requests

--- a/setup.py
+++ b/setup.py
@@ -86,7 +86,7 @@ setup(
         ],
     },
     extras_require={
-        "cargo": ["toml"],
+        "cargo": ['tomli; python_version < "3.11"'],
     },
     zip_safe=False,
 )

--- a/src/buildstream_plugins/sources/cargo.py
+++ b/src/buildstream_plugins/sources/cargo.py
@@ -70,7 +70,13 @@ import tarfile
 import urllib.error
 import urllib.request
 
-import toml
+# We prefer tomli that was put into standard library as tomllib
+# starting from 3.11
+try:
+    import tomllib  # type: ignore
+except ImportError:
+    import tomli as tomllib  # type: ignore
+
 from buildstream import Source, SourceFetcher, SourceError
 from buildstream import utils
 
@@ -380,8 +386,8 @@ class CargoSource(Source):
         try:
             with open(lockfile, "r", encoding="utf-8") as f:
                 try:
-                    lock = toml.load(f)
-                except toml.TomlDecodeError as e:
+                    lock = tomllib.load(f)
+                except tomllib.TOMLDecodeError as e:
                     raise SourceError(
                         "Malformed Cargo.lock file at: {}".format(self.cargo_lock),
                         detail="{}".format(e),


### PR DESCRIPTION
Since tomli got into standard library with Python 3.11, accept
it as the de facto toml implementation. This way we get fully
functional cargo plugin starting from 3.11 without any additional
dependencies.