### PR TITLE
Use docs subfolder for gh-pages deployment

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -36,4 +36,4 @@ github:
 
   # Enable pages publishing
   ghp_branch: gh-pages
-  ghp_path: ~
+  ghp_path: /docs

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -66,14 +66,15 @@ jobs:
         #
         cd pages/
         git reset --hard GH_PAGES_FIRST_COMMIT
-
+        mkdir docs
         # Copy the docs asset over and overwrite the orphan gh-pages branch, ensure
         # that we disable GitHub's jekyll by creating the .nojekyll file, otherwise
         # it will interfere with the rendering of the site.
         #
-        cp -a ../docs/doc/build/html/* .
-        cp -a ../docs/docs.tgz .
+        cp -a ../docs/doc/build/html/* docs
+        cp -a ../docs/docs.tgz docs
         touch .nojekyll
+        touch docs/.nojekyll
 
         git add .
         git config --local user.email "merge-ci@ponyland"


### PR DESCRIPTION
Trying to use the /docs dir to get the pages to work