### PR TITLE
README, setup.py: Add more project links

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,10 +1,10 @@
 BuildStream Plugins
 ===================
-A collection of plugins for the BuildStream project.
+A collection of plugins for the `BuildStream <https://buildstream.build>`_ project.
 
 
 How to use plugins
 ------------------
-Plugins must be declared by your buildstream project.conf for use in your
-project. For instructions on how to load plugins in your buildstream project,
+Plugins must be declared by your BuildStream project.conf for use in your
+project. For instructions on how to load plugins in your BuildStream project,
 please consult the `plugin loading documentation <https://docs.buildstream.build/master/format_project.html#loading-plugins>`_

--- a/setup.py
+++ b/setup.py
@@ -66,6 +66,9 @@ setup(
     url="https://buildstream.build",
     project_urls={
         "Documentation": "https://apache.github.io/buildstream-plugins/",
+        "Source": "https://github.com/apache/buildstream-plugins/",
+        "Tracker": "https://github.com/apache/buildstream-plugins/issues",
+        "Mailing List": "https://lists.apache.org/list.html?dev@buildstream.apache.org",
     },
     package_dir={"": "src"},
     packages=find_packages(where="src"),


### PR DESCRIPTION
This is mostly to spruce up our PyPI project page: https://pypi.org/project/buildstream-plugins/