### PR TITLE
cargo: Avoid adding extra / after url

### DIFF
--- a/src/buildstream_plugins/sources/cargo.py
+++ b/src/buildstream_plugins/sources/cargo.py
@@ -67,6 +67,7 @@ import shutil
 import tarfile
 import urllib.error
 import urllib.request
+from urllib.parse import urljoin
 
 # We prefer tomli that was put into standard library as tomllib
 # starting from 3.11
@@ -270,7 +271,8 @@ class Crate(SourceFetcher):
     #
     def _get_url(self, alias=None):
         url = self.cargo.translate_url(self.cargo.url, alias_override=alias)
-        return "{url}/{name}/{name}-{version}.crate".format(url=url, name=self.name, version=self.version)
+        path = "{name}/{name}-{version}.crate".format(name=self.name, version=self.version)
+        return urljoin(f"{url}/", path)
 
     # _get_etag()
     #


### PR DESCRIPTION
If the index URL, as configured by the project, ended in a /, then the cargo plugin would append another slash when generating the full URL of a crate. This would generate a URL with two slashes.

This would cause "Permission Denied" errors from cargo's hosting.

Some projects have a convention that all URL aliases should end with a /. This change permits projects to continue doing so