### PR TITLE
cargo: call mark_download_url with the correct url

### DIFF
--- a/src/buildstream_plugins/sources/cargo.py
+++ b/src/buildstream_plugins/sources/cargo.py
@@ -109,7 +109,7 @@ class Crate(SourceFetcher):
         self.name = name
         self.version = str(version)
         self.sha = sha
-        self.mark_download_url(self._get_url())
+        self.mark_download_url(cargo.url)
 
     ########################################################
     #     SourceFetcher API method implementations         #


### PR DESCRIPTION
We want to give it the untranslated url, so that mirroring works. We also should use the url that is defined in the config (i.e. the base url rather than the constructed url for the crate)