### PR TITLE
sources/pip.py: Support Python 3.12 and future versions

### DIFF
--- a/src/buildstream_plugins/sources/pip.py
+++ b/src/buildstream_plugins/sources/pip.py
@@ -93,6 +93,7 @@ _PYTHON_VERSIONS = [
     "python3.10",
     "python3.11",
     "python3.12",
+    "python3",
 ]
 
 # List of allowed extensions taken from

--- a/src/buildstream_plugins/sources/pip.py
+++ b/src/buildstream_plugins/sources/pip.py
@@ -92,6 +92,7 @@ _PYTHON_VERSIONS = [
     "python3.9",
     "python3.10",
     "python3.11",
+    "python3.12",
 ]
 
 # List of allowed extensions taken from


### PR DESCRIPTION
This adds `python3.12` and `python3` to the list of Python commands. The latter allows use of the Python 3.x version that is configured as default on the host and will also make the plugin work with future Python 3.x versions that aren't yet listed explicitly.