### PR TITLE
Minor cleanup for .asf.yaml and mypy configurations

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -34,6 +34,9 @@ github:
     # disable rebase button:
     rebase: false
 
+  # Close branches when pull requests are merged
+  del_branch_on_merge: true
+
   # Enable pages publishing
   ghp_branch: gh-pages
   ghp_path: /docs

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,8 +28,3 @@ env =
 files = src
 warn_unused_configs = True
 warn_no_return = True
-
-# Ignore missing stubs for third-party packages.
-# In future, these should be re-enabled if/when stubs for them become available.
-[mypy-copyreg,grpc,pluginbase,psutil,pyroaring,ruamel,multiprocessing.forkserver]
-ignore_missing_imports=True


### PR DESCRIPTION
*   setup.cfg: Remove unnecessary mypy ignores for 3rd party packages

    For all these - either buildstream-plugins project does not use them, or
    they come with types at this time.

*   .asf.yaml: Delete pull request branches after merging