### PR TITLE
git.py: Add tagger to annotated tag

### DIFF
--- a/src/buildstream_plugins/sources/git.py
+++ b/src/buildstream_plugins/sources/git.py
@@ -654,7 +654,9 @@ class GitMirror(SourceFetcher):
             for tag, commit_ref, annotated in self.tags:
                 if annotated:
                     with TemporaryFile(dir=tmpdir) as tag_file:
-                        tag_data = "object {}\ntype commit\ntag {}\n".format(commit_ref, tag)
+                        tag_data = "object {}\ntype commit\ntag {}\ntagger Unspecified Tagger <unspecified-tagger> 0 +0000\n".format(
+                            commit_ref, tag
+                        )
                         tag_file.write(tag_data.encode("ascii"))
                         tag_file.seek(0, 0)
                         _, tag_ref = self.source.check_output(


### PR DESCRIPTION
`git hash-object` 2.40+ fails without a tagger entry.

	error: object fails fsck: missingTaggerEntry: invalid format - expected 'tagger' line
	fatal: refusing to create malformed object

Only ancient versions of git created tag objects without tagger information.

As the `ref` does not currently contain tagger information, this uses a placeholder value that matches `git fast-export --fake-missing-tagger`.

Tracking the real tagger information in the `ref` could be considered for a follow-up.