### PR TITLE
ci: Upgrade from `docker-compose` to `docker compose`

### DIFF
--- a/.github/run-ci.sh
+++ b/.github/run-ci.sh
@@ -58,7 +58,7 @@ function runTest() {
     # Run docker-compose from it's directory, because it will use
     # relative paths
     cd "${topdir}/compose"
-    docker-compose \
+    docker compose \
         --env-file ${topdir}/common.env \
         --file ${topdir}/compose/ci.docker-compose.yml \
         run "${test_name}"


### PR DESCRIPTION
`docker-compose` (v1) is no longer available on GitHub runners. Use `docker compose` (v2) instead.