### PR TITLE
CI: Various fixes

### DIFF
--- a/.github/common.env
+++ b/.github/common.env
@@ -1,5 +1,5 @@
 # Shared common variables
 
-CI_IMAGE_VERSION=master-1408971201
+CI_IMAGE_VERSION=master-1571408207
 CI_TOXENV_ALL=py38,py39,py310,py311,py312
 CI_TOXENV_MASTER=py38-bst-master,py39-bst-master,py310-bst-master,py311-bst-master,py312-bst-master

--- a/.github/compose/ci.docker-compose.yml
+++ b/.github/compose/ci.docker-compose.yml
@@ -30,9 +30,9 @@ services:
     <<: *tests-template
     image: registry.gitlab.com/buildstream/buildstream-docker-images/testsuite-fedora:40-${CI_IMAGE_VERSION:-latest}
 
-  ubuntu-20.04:
+  ubuntu-22.04:
     <<: *tests-template
-    image: registry.gitlab.com/buildstream/buildstream-docker-images/testsuite-ubuntu:20.04-${CI_IMAGE_VERSION:-latest}
+    image: registry.gitlab.com/buildstream/buildstream-docker-images/testsuite-ubuntu:22.04-${CI_IMAGE_VERSION:-latest}
 
   # Ensure that tests also pass in the absence of a sandboxing tool
   fedora-missing-deps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
           - debian-11
           - fedora-40
           - fedora-missing-deps
-          - ubuntu-20.04
+          - ubuntu-22.04
           - lint
           - mypy
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ concurrency:
 
 jobs:
   tests:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     continue-on-error: ${{ matrix.allow-failure || false }}
 
     strategy:
@@ -59,7 +59,7 @@ jobs:
           ${GITHUB_WORKSPACE}/.github/run-ci.sh ${{ matrix.test-name }}
 
   docs:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Check out repository
         uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,7 +75,7 @@ jobs:
           ${GITHUB_WORKSPACE}/.github/run-ci.sh docs
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: docs
           path: doc/build/html

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   build:
     name: Build documentation
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - name: Checkout code
       uses: actions/checkout@v2
@@ -40,7 +40,7 @@ jobs:
 
   publish:
     needs: build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
 
     - name: Download artifact

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -31,7 +31,7 @@ jobs:
         tar -C doc/build/html -zcf docs.tgz .
 
     - name: Upload artifacts
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: docs
         path: |
@@ -44,7 +44,7 @@ jobs:
     steps:
 
     - name: Download artifact
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v4
       with:
         name: docs
         path: docs

--- a/.pylintrc
+++ b/.pylintrc
@@ -111,6 +111,7 @@ disable=
         too-many-lines,
         too-many-locals,
         too-many-nested-blocks,
+	too-many-positional-arguments,
         too-many-public-methods,
         too-many-statements,
         too-many-return-statements,

--- a/tests/bzr_wrapper
+++ b/tests/bzr_wrapper
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+if [ -x "/usr/bin/bzr" ]; then
+
+    cat > "${1}/bzr" << 'EOF'
+#!/bin/bash
+
+export PATH=/usr/bin
+
+exec /usr/bin/bzr "$@"
+EOF
+
+    chmod +x "${1}/bzr"
+fi

--- a/tox.ini
+++ b/tox.ini
@@ -60,7 +60,7 @@ setenv =
     !master: BST_VERSION = 2.2.1
     master: BST_VERSION = master
 
-whitelist_externals =
+allowlist_externals =
     py{38,39,310,311,312}:
         mv
         mkdir
@@ -132,7 +132,7 @@ passenv =
     HOME
     LANG
     LC_ALL
-whitelist_externals =
+allowlist_externals =
     make
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -27,6 +27,7 @@ skip_missing_interpreters = true
 [testenv]
 commands =
     bst --version
+    ./tests/bzr_wrapper {envdir}/bin
     pytest --basetemp {envtmpdir} {posargs}
 deps =
     -rrequirements/test-requirements.txt
@@ -64,6 +65,7 @@ allowlist_externals =
     py{38,39,310,311,312}:
         mv
         mkdir
+	./tests/bzr_wrapper
 
 #
 # Code formatters


### PR DESCRIPTION
This uses ubuntu 22.04 runners, as a workaround for https://issues.apache.org/jira/browse/INFRA-26331, as outlined here: https://etbe.coker.com.au/2024/04/24/ubuntu-24-04-bubblewrap/ bubblewrap is not working on ubuntu 24 without some adjustments.

Also this fixes some linting errors, updates the artifact APIs, uses a new testsuite image which contains bzr, and fixes bzr tests, so all tests are working again.