### PR TITLE
 Drop support for Python 3.8 and add support for Python 3.13

### DIFF
--- a/.github/common.env
+++ b/.github/common.env
@@ -1,5 +1,5 @@
 # Shared common variables
 
 CI_IMAGE_VERSION=master-1571408207
-CI_TOXENV_ALL=py38,py39,py310,py311,py312
-CI_TOXENV_MASTER=py38-bst-master,py39-bst-master,py310-bst-master,py311-bst-master,py312-bst-master
+CI_TOXENV_ALL=py39,py310,py311,py312
+CI_TOXENV_MASTER=py39-bst-master,py310-bst-master,py311-bst-master,py312-bst-master

--- a/.github/common.env
+++ b/.github/common.env
@@ -1,5 +1,5 @@
 # Shared common variables
 
 CI_IMAGE_VERSION=master-1571408207
-CI_TOXENV_ALL=py39,py310,py311,py312
-CI_TOXENV_MASTER=py39-bst-master,py310-bst-master,py311-bst-master,py312-bst-master
+CI_TOXENV_ALL=py39,py310,py311,py312,py313
+CI_TOXENV_MASTER=py39-bst-master,py310-bst-master,py311-bst-master,py312-bst-master,py313-bst-master

--- a/.github/compose/ci.docker-compose.yml
+++ b/.github/compose/ci.docker-compose.yml
@@ -30,6 +30,10 @@ services:
     <<: *tests-template
     image: registry.gitlab.com/buildstream/buildstream-docker-images/testsuite-fedora:40-${CI_IMAGE_VERSION:-latest}
 
+  fedora-41:
+    <<: *tests-template
+    image: registry.gitlab.com/buildstream/buildstream-docker-images/testsuite-fedora:41-${CI_IMAGE_VERSION:-latest}
+
   ubuntu-22.04:
     <<: *tests-template
     image: registry.gitlab.com/buildstream/buildstream-docker-images/testsuite-ubuntu:22.04-${CI_IMAGE_VERSION:-latest}

--- a/.github/run-ci.sh
+++ b/.github/run-ci.sh
@@ -67,7 +67,7 @@ function runTest() {
 
 
 if [ -z "${test_names}" ]; then
-    for test_name in "mypy debian-11 fedora-40 fedora-missing-deps ubuntu-20.04"; do
+    for test_name in "mypy debian-11 fedora-40 fedora-missing-deps ubuntu-22.04"; do
 	if ! runTest "${test_name}"; then
 	    echo "Tests failed"
 	    exit 1

--- a/.github/run-ci.sh
+++ b/.github/run-ci.sh
@@ -67,7 +67,7 @@ function runTest() {
 
 
 if [ -z "${test_names}" ]; then
-    for test_name in "mypy debian-11 fedora-40 fedora-missing-deps ubuntu-22.04"; do
+    for test_name in "mypy debian-11 fedora-40 fedora-41 fedora-missing-deps ubuntu-22.04"; do
 	if ! runTest "${test_name}"; then
 	    echo "Tests failed"
 	    exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,7 @@ jobs:
         test-name:
           - debian-11
           - fedora-40
+          - fedora-41
           - fedora-missing-deps
           - ubuntu-22.04
           - lint

--- a/requirements/test-requirements.txt
+++ b/requirements/test-requirements.txt
@@ -8,4 +8,5 @@ pylint
 pycodestyle
 pyftpdlib
 responses
+setuptools
 wheel

--- a/setup.py
+++ b/setup.py
@@ -57,6 +57,7 @@ setup(
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",
+        "Programming Language :: Python :: 3.13",
         "Topic :: Software Development :: Build Tools",
     ],
     description="A collection of plugins for BuildStream.",

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,6 @@ setup(
         "License :: OSI Approved :: Apache Software License",
         "Operating System :: POSIX",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",

--- a/tox.ini
+++ b/tox.ini
@@ -58,7 +58,7 @@ setenv =
     py{39,310,311,312,313}: XDG_CACHE_HOME = {envtmpdir}/cache
     py{39,310,311,312,313}: XDG_CONFIG_HOME = {envtmpdir}/config
     py{39,310,311,312,313}: XDG_DATA_HOME = {envtmpdir}/share
-    !master: BST_VERSION = 2.2.1
+    !master: BST_VERSION = 2.4.0
     master: BST_VERSION = master
 
 allowlist_externals =

--- a/tox.ini
+++ b/tox.ini
@@ -16,7 +16,7 @@
 # Tox global configuration
 #
 [tox]
-envlist = py{39,310,311,312}-{bst-fixed,bst-master}
+envlist = py{39,310,311,312,313}-{bst-fixed,bst-master}
 skip_missing_interpreters = true
 
 #
@@ -55,14 +55,14 @@ passenv =
 # These keys are not inherited by any other sections
 #
 setenv =
-    py{39,310,311,312}: XDG_CACHE_HOME = {envtmpdir}/cache
-    py{39,310,311,312}: XDG_CONFIG_HOME = {envtmpdir}/config
-    py{39,310,311,312}: XDG_DATA_HOME = {envtmpdir}/share
+    py{39,310,311,312,313}: XDG_CACHE_HOME = {envtmpdir}/cache
+    py{39,310,311,312,313}: XDG_CONFIG_HOME = {envtmpdir}/config
+    py{39,310,311,312,313}: XDG_DATA_HOME = {envtmpdir}/share
     !master: BST_VERSION = 2.2.1
     master: BST_VERSION = master
 
 allowlist_externals =
-    py{39,310,311,312}:
+    py{39,310,311,312,313}:
         mv
         mkdir
 	./tests/bzr_wrapper

--- a/tox.ini
+++ b/tox.ini
@@ -16,7 +16,7 @@
 # Tox global configuration
 #
 [tox]
-envlist = py{38,39,310,311,312}-{bst-fixed,bst-master}
+envlist = py{39,310,311,312}-{bst-fixed,bst-master}
 skip_missing_interpreters = true
 
 #
@@ -55,14 +55,14 @@ passenv =
 # These keys are not inherited by any other sections
 #
 setenv =
-    py{38,39,310,311,312}: XDG_CACHE_HOME = {envtmpdir}/cache
-    py{38,39,310,311,312}: XDG_CONFIG_HOME = {envtmpdir}/config
-    py{38,39,310,311,312}: XDG_DATA_HOME = {envtmpdir}/share
+    py{39,310,311,312}: XDG_CACHE_HOME = {envtmpdir}/cache
+    py{39,310,311,312}: XDG_CONFIG_HOME = {envtmpdir}/config
+    py{39,310,311,312}: XDG_DATA_HOME = {envtmpdir}/share
     !master: BST_VERSION = 2.2.1
     master: BST_VERSION = master
 
 allowlist_externals =
-    py{38,39,310,311,312}:
+    py{39,310,311,312}:
         mv
         mkdir
 	./tests/bzr_wrapper

--- a/tox.ini
+++ b/tox.ini
@@ -106,7 +106,7 @@ skip_install = True
 commands =
     mypy {posargs}
 deps =
-    mypy==1.11.0
+    mypy==1.13.0
     types-protobuf
     types-python-dateutil
     types-setuptools


### PR DESCRIPTION
This matches BuildStream: https://github.com/apache/buildstream/pull/1971