### PR TITLE
tox.ini: Bumping buildstream version to release candidate tag

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -58,7 +58,7 @@ setenv =
     py{39,310,311,312,313}: XDG_CACHE_HOME = {envtmpdir}/cache
     py{39,310,311,312,313}: XDG_CONFIG_HOME = {envtmpdir}/config
     py{39,310,311,312,313}: XDG_DATA_HOME = {envtmpdir}/share
-    !master: BST_VERSION = ad25c4ba0e6947013cc59c9e6e88a235329292d2
+    !master: BST_VERSION = 2.5.0.dev1
     master: BST_VERSION = master
 
 allowlist_externals =


### PR DESCRIPTION
This needs to happen before the release because otherwise the documentation is not building, due to a recent cython breakage.