### PR TITLE
Small fixes on the cmake element

### DIFF
--- a/src/buildstream_plugins/elements/cmake.yaml
+++ b/src/buildstream_plugins/elements/cmake.yaml
@@ -35,7 +35,7 @@ variables:
 
     cmake -B%{build-dir} -H"%{conf-root}" -G"%{generator}" %{cmake-args}
 
-  make: cmake --build %{build-dir} -- ${JOBS}
+  make: cmake --build %{build-dir}
   make-install: env DESTDIR="%{install-root}" cmake %{build-dir} --install
 
   # Set this if the sources cannot handle parallelization.
@@ -72,9 +72,9 @@ config:
 
 # Use max-jobs CPUs for building and enable verbosity
 environment:
-  JOBS: -j%{max-jobs}
+  CMAKE_BUILD_PARALLEL_LEVEL: %{max-jobs}
 
-# And dont consider JOBS as something which may
+# And dont consider CMAKE_BUILD_PARALLEL_LEVEL as something which may
 # affect build output.
 environment-nocache:
-- JOBS
+- CMAKE_BUILD_PARALLEL_LEVEL


### PR DESCRIPTION
* Fix cmake double builds, implements it as it was [workarounded](https://gitlab.com/freedesktop-sdk/freedesktop-sdk/-/blob/master/include/_private/cmake-conf.yml?ref_type=heads#L8) already on the freedesktop-sdk
* Use cmake env [CMAKE_BUILD_PARALLEL_LEVEL](https://cmake.org/cmake/help/latest/envvar/CMAKE_BUILD_PARALLEL_LEVEL.html) to tell the amount of jobs to execute at once rather than passing the argument to ninja/make