### PR TITLE
pyproject.toml: drop unneeded dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,13 +12,8 @@
 #  limitations under the License.
 #
 [build-system]
-requires = [
-    # We need at least version 36.6.0 that introduced "build_meta"
-    "setuptools>=36.6.0",
-    # In order to build wheels, and as required by PEP 517
-    "wheel",
-    "Cython"
-]
+# We need at least version 36.6.0 that introduced "build_meta"
+requires = ["setuptools>=36.6.0"]
 build-backend = "setuptools.build_meta"
 
 [tool.black]


### PR DESCRIPTION
We don't use cython here, and PEP 517 doesn't require declaring a dependency on wheel