### PR TITLE
Document how to get plugins

### DIFF
--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -18,8 +18,11 @@ BuildStream Plugins Documentation
 =================================
 This is a collection of plugins to use with Buildstream.
 
-To these plugins in your project, follow the
-`plugin loading documentation <https://docs.buildstream.build/master/format_project.html#loading-plugins>`_.
+To use these plugins in your project, can install them though 
+`pip <https://pypi.org/project/buildstream-plugins/>`_.
+Then, follow the
+`plugin loading documentation <https://docs.buildstream.build/master/format_project.html#loading-plugins>`_
+so your project can utilize them.
 
 .. toctree::
    :maxdepth: 1


### PR DESCRIPTION
Currently, the docs describe only how to use the plugins, but now how to get them in the first place. Also, there was a grammar error. I have pointed out that users can install `buildstream-plugins` through pip.