### PR TITLE
Update .pylintrc

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -547,4 +547,4 @@ valid-metaclass-classmethod-first-arg=mcs
 
 # Exceptions that will emit a warning when being caught. Defaults to
 # "Exception"
-overgeneral-exceptions=Exception
+overgeneral-exceptions=builtins.Exception

--- a/.pylintrc
+++ b/.pylintrc
@@ -51,10 +51,6 @@ persistent=yes
 # Specify a configuration file.
 #rcfile=
 
-# When enabled, pylint would attempt to guess common misconfiguration and emit
-# user-friendly hints instead of false-positive error messages
-suggestion-mode=yes
-
 # Allow loading of arbitrary C extensions. Extensions are imported into the
 # active Python interpreter and may run arbitrary code.
 unsafe-load-any-extension=no


### PR DESCRIPTION
Small fixes for warnings/errors with Pylint 4.0. Both of these changes are already in the main BuildStream repository.